### PR TITLE
#49 - Use check item to show "Always on top" status

### DIFF
--- a/Components/MenuHandler.Component.cs
+++ b/Components/MenuHandler.Component.cs
@@ -18,9 +18,9 @@ namespace Components
         public void OnBeforeContextMenu(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, IMenuModel model)
         {
             this.menuHandlerService.ClearModel(model);
-            this.menuHandlerService.AddOption("Toggle Move", 0, model);
-            this.menuHandlerService.AddOption("Toggle Always on Top", 1, model);
-            this.menuHandlerService.AddOption("Close Widget", 2, model);
+            this.menuHandlerService.AddOption("Move", 0, false, model);
+            this.menuHandlerService.AddOption("Always on Top", 1, widgetComponent.window.TopMost, model);
+            this.menuHandlerService.AddOption("Close Widget", 2, false, model);
         }
 
         public bool OnContextMenuCommand(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IContextMenuParams parameters, CefMenuCommand commandId, CefEventFlags eventFlags)

--- a/Services/MenuHandler.Service.cs
+++ b/Services/MenuHandler.Service.cs
@@ -19,9 +19,10 @@ namespace Services
         /// <param name="option">Name of the option to add</param>
         /// <param name="index">ID of the position of the option</param>
         /// <param name="model">Model of the menu to add the option to</param>
-        public void AddOption(string option, int index, IMenuModel model)
+        public void AddOption(string option, int index, bool checkd, IMenuModel model)
         {
-            model.AddItem((CefMenuCommand)index, option);
+            model.AddCheckItem((CefMenuCommand)index, option);
+            model.SetChecked((CefMenuCommand)index, checkd);
         }
     }
 }


### PR DESCRIPTION
I also renamed "Toggle move" into "Move", as IMHO it doesn't toggle anything (since when you click, the move is finished). But it can be considered opinionated and reverted.