### PR TITLE
#45 : persist "always on top" state across restart

### DIFF
--- a/Components/Widget.Component.cs
+++ b/Components/Widget.Component.cs
@@ -65,7 +65,7 @@ namespace Components
             window.Controls.Add(browser);
         }
 
-        public override void CreateWindow(int width, int height, string title, bool save, Point position = default(Point))
+        public override void CreateWindow(int width, int height, string title, bool save, Point position = default(Point), bool? alwaysOnTop = null)
         {
             new Thread(() =>
             {
@@ -84,6 +84,7 @@ namespace Components
                 int locationY = locationString != null ? int.Parse(locationString.Split(' ')[1]) : mousePos.Y;
                 byte opacity = (byte)(opacityString != null ? byte.Parse(opacityString.Split(' ')[0]) : 255);
                 bool topMost = topMostString != null ? bool.Parse(topMostString.Split(' ')[0]) : false;
+                topMost = alwaysOnTop.HasValue ? (bool)alwaysOnTop : topMost;
 
                 window = new WidgetForm();
                 window.Size = new Size(this.width, this.height);
@@ -103,7 +104,7 @@ namespace Components
 
                 if (save)
                 {
-                    this.widgetService.AddOrUpdateSession(htmlPath, new Point(locationX, locationY));
+                    this.widgetService.AddOrUpdateSession(htmlPath, new Point(locationX, locationY), topMost);
                     AssetService.OverwriteConfigurationFile(AssetService.GetConfigurationFile());
                 }
 
@@ -134,7 +135,7 @@ namespace Components
                 window.Invoke(new MethodInvoker(delegate ()
                 {
                     window.Location = new Point(pos.X - width / 2, pos.Y - height / 2);
-                    this.widgetService.AddOrUpdateSession(this.htmlPath, window.Location);
+                    this.widgetService.AddOrUpdateSession(this.htmlPath, window.Location, window.TopMost);
                 }));
             }
         }

--- a/Components/WidgetsManager.Component.cs
+++ b/Components/WidgetsManager.Component.cs
@@ -96,7 +96,7 @@ namespace Components
             CreateWindow(width, height, "WinWidgets", false);
         }
 
-        public override void CreateWindow(int width, int height, string title, bool save, Point position = default(Point))
+        public override void CreateWindow(int width, int height, string title, bool save, Point position = default(Point), bool? alwaysOnTop = null)
         {
             window = new WidgetForm(false);
             window.Size = new Size(width, height);
@@ -175,7 +175,8 @@ namespace Components
                 OpenWidget(widgetConfiguration.path, new Point(
                     widgetConfiguration.position.X, 
                     widgetConfiguration.position.Y
-                ));
+                ),
+                widgetConfiguration.alwaysOnTop);
             }
         }
 
@@ -188,13 +189,13 @@ namespace Components
             widget.CreateWindow(300, 300, $"Widget{id}", true);
         }
 
-        public override void OpenWidget(string path, Point position)
+        public override void OpenWidget(string path, Point position, bool? alwaysOnTop)
         {
             WidgetComponent widget = new WidgetComponent();
             AssetService.widgets.AddWidget(widget);
 
             widget.htmlPath = path;
-            widget.CreateWindow(300, 300, $"Widget{path}", false, position);
+            widget.CreateWindow(300, 300, $"Widget{path}", false, position, alwaysOnTop);
         }
 
         private void OnStopAllWidgets(object sender, EventArgs e)

--- a/Models/Configuration.Model.cs
+++ b/Models/Configuration.Model.cs
@@ -14,6 +14,8 @@ namespace Models
         /// Position on the screen where the widget was last seen
         /// </summary>
         public Point position { get; set; }
+
+        public bool alwaysOnTop { get; set; }
     }
 
     internal struct Configuration

--- a/Models/Widget.Model.cs
+++ b/Models/Widget.Model.cs
@@ -41,7 +41,7 @@ namespace Models
         /// <param name="title">Title of the window</param>
         /// <param name="save">Should the widget be saved immediately upon creation to the config.js file</param>
         /// <param name="position">Position of the window</param>
-        abstract public void CreateWindow(int width, int height, string title, bool save, Point position = default(Point));
+        abstract public void CreateWindow(int width, int height, string title, bool save, Point position = default(Point), bool? alwaysOnTop = null);
 
         /// <summary>
         /// Appends the widget control to the window

--- a/Models/WidgetManager.Model.cs
+++ b/Models/WidgetManager.Model.cs
@@ -13,8 +13,10 @@ namespace Models
         /// <summary>
         /// Opens widget by its path
         /// </summary>
-        /// <param name="path"></param>
-        abstract public void OpenWidget(string path, Point position);
+        /// <param name="path">path of the widget to open</param>
+        /// <param name="position">position where to open the widget</param>
+        /// <param name="alwayOnTop">whether "Always on Top" flag of the widget must be set. If null, use the default</param>
+        abstract public void OpenWidget(string path, Point position, bool? alwaysOnTop);
 
         /// <summary>
         /// Automatically starts all widgets in the config.js list 

--- a/Services/Widget.Service.cs
+++ b/Services/Widget.Service.cs
@@ -29,6 +29,7 @@ namespace Services
             widget.window.Invoke(new MethodInvoker(delegate ()
             {
                 widget.window.TopMost = !widget.window.TopMost;
+                AddOrUpdateSession(widget.htmlPath, widget.window.Location, widget.window.TopMost);
             }));
         }
 
@@ -78,7 +79,8 @@ namespace Services
         /// </summary>
         /// <param name="path">Path of the widget</param>
         /// <param name="position">Position of the widget</param>
-        public void AddOrUpdateSession(string path, Point position)
+        /// <param name="alwaysOnTop">Whether the widget is "Always on top"</param>
+        public void AddOrUpdateSession(string path, Point position, bool alwaysOnTop)
         {
             Configuration configuration = AssetService.GetConfigurationFile();
 
@@ -89,7 +91,8 @@ namespace Services
                     configuration.lastSessionWidgets[i] = new WidgetConfiguration()
                     {
                         path = path,
-                        position = position
+                        position = position,
+                        alwaysOnTop = alwaysOnTop
                     };
 
                     AssetService.OverwriteConfigurationFile(configuration);


### PR DESCRIPTION
In this PR :
* When a widget is reloaded, if it was "Always on top" in the previous session, this state is restored.

Note that it doesn't work in the following case :
* a Widget has the meta "topMost" set to true
* I open the widget, and unset "Always on top"
* when the widget is reloaded, the state is NOT restored (because there is no difference between the state being set to false, and it being left as-is, so we use the value of the meta)

Using a null value rather than a plain bool should fix it. But I have to learn .net a little more first :)

Anyway, while developing, I found #51 that prevents this PR to work as intended.
So this PR is blocked until #51 is solved.