### PR TITLE
feat: external links can now be opened from within widgets

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -10,3 +10,4 @@ mateuszstalmach | <https://github.com/mateuszstalmach>
 EPICTROLLTOAST | <https://github.com/EPICTROLLTOAST>
 Yopai | <https://github.com/Yopai>
 beyenilmez | <https://github.com/beyenilmez>
+Lyle Brown | <https://github.com/lylebrown>

--- a/Components/Widget.Component.cs
+++ b/Components/Widget.Component.cs
@@ -1,4 +1,5 @@
 ﻿using CefSharp;
+using CefSharp.Handler;
 using CefSharp.WinForms;
 using Microsoft.Win32;
 using Models;
@@ -7,9 +8,11 @@ using Newtonsoft.Json;
 using Services;
 using System;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Timers;
 using System.Windows.Forms;
+using WidgetsDotNet.Models;
 
 namespace Components
 {
@@ -50,7 +53,15 @@ namespace Components
         public override ChromiumWebBrowser browser
         {
             get { return _browser; }
-            set { _browser = value; }
+            set 
+            { 
+                _browser = value; 
+
+                if (_browser != null)
+                {
+                    _browser.RequestHandler = new CustomRequestHandler();
+                }
+            }
         }
 
         public override Configuration configuration

--- a/Components/Widget.Component.cs
+++ b/Components/Widget.Component.cs
@@ -1,18 +1,15 @@
-﻿using CefSharp;
-using CefSharp.Handler;
+﻿using System;
+using System.Drawing;
+using System.Threading;
+using System.Timers;
+using System.Windows.Forms;
+using CefSharp;
 using CefSharp.WinForms;
 using Microsoft.Win32;
 using Models;
 using Modules;
 using Newtonsoft.Json;
 using Services;
-using System;
-using System.Drawing;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Timers;
-using System.Windows.Forms;
-using WidgetsDotNet.Models;
 
 namespace Components
 {

--- a/Models/CustomRequestHandler.Model.cs
+++ b/Models/CustomRequestHandler.Model.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using CefSharp;
 
-namespace WidgetsDotNet.Models
+namespace Models
 {
     public class CustomRequestHandler : IRequestHandler
     {

--- a/Models/CustomRequestHandler.Model.cs
+++ b/Models/CustomRequestHandler.Model.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using CefSharp;
+
+namespace WidgetsDotNet.Models
+{
+    public class CustomRequestHandler : IRequestHandler
+    {
+        private readonly string _userAgent = "WinWidgetsUserAgent";
+
+        private readonly List<string> _excludedProtocols = new List<string>() { "http", "https", "file" };
+
+        public bool OnBeforeBrowse(IWebBrowser chromium, IBrowser browser, IFrame frame, IRequest request, bool gesture, bool redirect)
+        {
+            string protocol = request.Url.Split(':')[0];
+
+            if (_excludedProtocols.Contains(protocol))
+            {
+                return false;
+            }
+
+            if (request.Url.Contains(':'))
+            {
+                Process.Start(new ProcessStartInfo(request.Url) { UseShellExecute = true });
+                return true;
+            }
+
+            return false;
+        }
+
+        public IResourceRequestHandler GetResourceRequestHandler(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, bool isNavigation, bool isDownload, string requestInitiator, ref bool disableDefaultHandling)
+        {
+            return new CustomResourceRequestHandler(_userAgent);
+        }
+
+        public bool GetAuthCredentials(IWebBrowser chromiumWebBrowser, IBrowser browser, string originUrl, bool isProxy, string host, int port, string realm, string scheme, IAuthCallback callback) => false;
+
+        public bool OnCertificateError(IWebBrowser chromiumWebBrowser, IBrowser browser, CefErrorCode errorCode, string requestUrl, ISslInfo sslInfo, IRequestCallback callback) => false;
+
+        public void OnDocumentAvailableInMainFrame(IWebBrowser chromiumWebBrowser, IBrowser browser) { }
+
+        public bool OnOpenUrlFromTab(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, string targetUrl, WindowOpenDisposition targetDisposition, bool userGesture) => false;
+
+        public void OnRenderProcessTerminated(IWebBrowser chromiumWebBrowser, IBrowser browser, CefTerminationStatus status, int errorCode, string errorMessage) { }
+
+        public void OnRenderViewReady(IWebBrowser chromiumWebBrowser, IBrowser browser) { }
+
+        public bool OnSelectClientCertificate(IWebBrowser chromiumWebBrowser, IBrowser browser, bool isProxy, string host, int port, X509Certificate2Collection certificates, ISelectClientCertificateCallback callback) => false;
+    }
+}

--- a/Models/CustomResourceRequestHandler.cs
+++ b/Models/CustomResourceRequestHandler.cs
@@ -1,0 +1,23 @@
+﻿using CefSharp;
+using CefSharp.Handler;
+
+namespace WidgetsDotNet.Models
+{
+    internal class CustomResourceRequestHandler : ResourceRequestHandler
+    {
+        private readonly string userAgent;
+
+        public CustomResourceRequestHandler(string userAgent)
+        {
+            this.userAgent = userAgent;
+        }
+
+        protected override CefReturnValue OnBeforeResourceLoad(IWebBrowser chromiumWebBrowser, IBrowser browser, IFrame frame, IRequest request, IRequestCallback callback)
+        {
+            var headers = request.Headers;
+            headers["User-Agent"] = userAgent;
+            request.Headers = headers;
+            return base.OnBeforeResourceLoad(chromiumWebBrowser, browser, frame, request, callback);
+        }
+    }
+}

--- a/Models/CustomResourceRequestHandler.cs
+++ b/Models/CustomResourceRequestHandler.cs
@@ -1,7 +1,7 @@
 ﻿using CefSharp;
 using CefSharp.Handler;
 
-namespace WidgetsDotNet.Models
+namespace Models
 {
     internal class CustomResourceRequestHandler : ResourceRequestHandler
     {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/beyluta/WinWidgets">
-    <img src="https://img.shields.io/badge/Version-1.5.0-green" alt="WinWidgets version" />
+    <img src="https://img.shields.io/badge/Version-1.5.1-green" alt="WinWidgets version" />
   </a>
 </p>
 

--- a/Services/Asset.Service.cs
+++ b/Services/Asset.Service.cs
@@ -37,7 +37,7 @@ namespace Services
         /// <summary>
         /// Semantic version of the application
         /// </summary>
-        static private string version = "1.5.0";
+        static private string version = "1.5.1";
 
         /// <summary>
         /// Gets the path where the HTML files (widgets) of the project are stored

--- a/WidgetsDotNet.csproj
+++ b/WidgetsDotNet.csproj
@@ -136,7 +136,9 @@
   <ItemGroup>
     <Compile Include="Hooks\HardwareActivity.Hook.cs" />
     <Compile Include="Models\Configuration.Model.cs" />
+    <Compile Include="Models\CustomRequestHandler.Model.cs" />
     <Compile Include="Models\Hardware.Model.cs" />
+    <Compile Include="Models\CustomResourceRequestHandler.cs" />
     <Compile Include="Models\Widget.Model.cs" />
     <Compile Include="Modules\WidgetForm.Module.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
# What's changed?

- Added feature to open external links from within widgets

## Browser Request Handling Enhancements

* Added a new `CustomRequestHandler` class (`Models/CustomRequestHandler.Model.cs`) implementing `IRequestHandler`, which intercepts browser requests, blocks navigation for non-standard protocols, and launches external processes for certain URLs. It also injects a custom user agent into resource requests.
* Introduced `CustomResourceRequestHandler` (`Models/CustomResourceRequestHandler.cs`), which sets a custom user agent header for outgoing requests.
* Updated the `browser` property setter in `Widget.Component.cs` to assign the new `CustomRequestHandler` to the Chromium browser instance.
* Updated using statements and references in `Widget.Component.cs` to support new handler classes. [[1]](diffhunk://#diff-272d6e01ca8a277224c9063dda297dddbee4405ad8942b7a15e7621a8b9b0994R2) [[2]](diffhunk://#diff-272d6e01ca8a277224c9063dda297dddbee4405ad8942b7a15e7621a8b9b0994R11-R15)
* Registered the new handler source files in the project file (`WidgetsDotNet.csproj`).

## Version Update

* Incremented application version from 1.5.0 to 1.5.1 in both `README.md` and `Asset.Service.cs`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-eefba579581951406b9794aa1b84b69ca8559a6211ed0b0070a40e0e293920d0L40-R40)